### PR TITLE
Refactor encryption handling in notification related classes

### DIFF
--- a/lib/config/navigation/app_navigation.dart
+++ b/lib/config/navigation/app_navigation.dart
@@ -5,7 +5,6 @@ import 'package:better_one/core/constants/notification_constants.dart';
 import 'package:better_one/core/utils/cache_service/cach_interface/locale_user_info.dart';
 import 'package:better_one/core/utils/dependency_locator/dependency_injection.dart';
 import 'package:better_one/core/utils/dependency_locator/inject.dart';
-import 'package:better_one/core/utils/encryption/encryption_handler.dart';
 import 'package:better_one/core/utils/methods/methods.dart';
 import 'package:better_one/core/utils/navigator_observer/app_navigator_observer.dart';
 import 'package:better_one/core/utils/notification_service/flutter_local_notification.dart';
@@ -59,18 +58,16 @@ class AppNavigation {
 
               if (notification != null &&
                   notification.didNotificationLaunchApp) {
-                var encryptedSenderId = await EncryptionHandler().encrypt(
-                    jsonDecode(notification.notificationResponse!.payload!)[
-                        NotificaitonConstants.senderId]);
+                var payloadFromNotification =
+                    jsonDecode(notification.notificationResponse!.payload!);
                 return state.namedLocation(
                   Routes.sharedTask.name,
                   pathParameters: {
-                    "id":
-                        jsonDecode(notification.notificationResponse!.payload!)[
-                            NotificaitonConstants.taskId]
+                    "id": payloadFromNotification[NotificaitonConstants.taskId]
                   },
                   queryParameters: {
-                    NotificaitonConstants.senderId: encryptedSenderId,
+                    NotificaitonConstants.senderId:
+                        payloadFromNotification[NotificaitonConstants.senderId],
                   },
                 );
               }

--- a/lib/core/utils/encryption/encryption_handler.dart
+++ b/lib/core/utils/encryption/encryption_handler.dart
@@ -3,6 +3,9 @@ import 'dart:async';
 import 'package:encrypt/encrypt.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
+// ignore: deprecated_member_use
+/// This class doesn't work correctly, it's left for debugging purposes
+/// Encrypts and decrypts strings using the encrypt package and stores the key in flutter secure storage.
 class EncryptionHandler {
   factory EncryptionHandler() => _instance;
   static final EncryptionHandler _instance = EncryptionHandler._();

--- a/lib/data_source/notification_data_source/firebase_notification_source.dart
+++ b/lib/data_source/notification_data_source/firebase_notification_source.dart
@@ -83,7 +83,7 @@ class FirebaseNotificationSource implements NotificationSourceInterface {
     } on FormatException catch (e) {
       return ResultHandler.failure(error: ParserFailure(message: e.message));
     } catch (e) {
-      kDebugPrint("Task from Notification$e");
+      kDebugPrint("Task from Notification exception:$e");
       return ResultHandler.failure(error: OtherFailure(message: e.toString()));
     }
   }

--- a/lib/view/pages/home/home_screen.dart
+++ b/lib/view/pages/home/home_screen.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:better_one/config/navigation/routes_enum.dart';
 import 'package:better_one/core/enum/task_status.dart';
 import 'package:better_one/core/utils/dependency_locator/dependency_injection.dart';
-import 'package:better_one/core/utils/encryption/encryption_handler.dart';
 import 'package:better_one/core/utils/methods/methods.dart';
 import 'package:better_one/core/utils/shared_widgets/failed.dart';
 import 'package:better_one/model/task_model/task_model.dart';
@@ -49,8 +48,6 @@ class _HomeScreenState extends State<HomeScreen> with RouteAware {
           kDebugPrint(
             "payload: ${jsonDecode(payload)[NotificaitonConstants.taskId]}, ${jsonDecode(payload)[NotificaitonConstants.senderId]}",
           );
-          var encryptedSenderId = await EncryptionHandler()
-              .encrypt(jsonDecode(payload)[NotificaitonConstants.senderId]);
           // ignore: use_build_context_synchronously
           context.goNamed(
             Routes.sharedTask.name,
@@ -58,7 +55,8 @@ class _HomeScreenState extends State<HomeScreen> with RouteAware {
               "id": jsonDecode(payload)[NotificaitonConstants.taskId]
             },
             queryParameters: {
-              NotificaitonConstants.senderId: encryptedSenderId,
+              NotificaitonConstants.senderId:
+                  jsonDecode(payload)[NotificaitonConstants.senderId],
             },
           );
         }

--- a/lib/view/pages/notification/notification_screen.dart
+++ b/lib/view/pages/notification/notification_screen.dart
@@ -2,7 +2,6 @@ import 'package:better_one/config/navigation/routes_enum.dart';
 import 'package:better_one/core/constants/lottie_assets.dart';
 import 'package:better_one/core/constants/notification_constants.dart';
 import 'package:better_one/core/errors/failure.dart';
-import 'package:better_one/core/utils/encryption/encryption_handler.dart';
 import 'package:better_one/core/utils/methods/methods.dart';
 import 'package:better_one/core/utils/shared_widgets/back_button_l10n.dart';
 import 'package:better_one/core/utils/shared_widgets/failed.dart';
@@ -143,15 +142,13 @@ class _NotificationScreenState extends State<NotificationScreen> {
                                 as Map<String, dynamic>);
                         return InkWell(
                           onTap: () async {
-                            var encryptedSenderId = await EncryptionHandler()
-                                .encrypt(notification.senderId);
                             if (context.mounted) {
                               context.pushNamed(
                                 Routes.sharedTask.name,
                                 pathParameters: {"id": notification.payload!},
                                 queryParameters: {
                                   NotificaitonConstants.senderId:
-                                      encryptedSenderId,
+                                      notification.senderId,
                                 },
                               );
                             }

--- a/lib/view_models/notification_viewmodel/notification_viewmodel.dart
+++ b/lib/view_models/notification_viewmodel/notification_viewmodel.dart
@@ -1,5 +1,4 @@
 import 'package:better_one/core/errors/failure.dart';
-import 'package:better_one/core/utils/encryption/encryption_handler.dart';
 import 'package:better_one/model/notification_model/notification_model.dart';
 import 'package:better_one/model/task_model/task_model.dart';
 import 'package:better_one/repositories/notification_repo/notification_repo_interface.dart';
@@ -82,10 +81,9 @@ class NotificationViewmodel extends Cubit<NotificationViewmodelState> {
     required String senderId,
   }) async {
     emit(const _GetTaskFromNotificationLoading());
-    var decryptedSenderId = await EncryptionHandler().decrypt(senderId);
     var result = await _notificationRepo.getTaskFromNotification(
       taskId: taskId,
-      senderId: decryptedSenderId,
+      senderId: senderId,
     );
     result.when(
       success: (task) {


### PR DESCRIPTION
Remove EncryptionHandler references and simplify encryption handling in
notification related classes by directly accessing payload data. This
improves code readability and reduces unnecessary encryption calls.